### PR TITLE
feat(suite): add .esolia/system.json suite descriptor

### DIFF
--- a/.esolia/system.json
+++ b/.esolia/system.json
@@ -1,0 +1,20 @@
+{
+  "name": "aichaku",
+  "purpose": "Methodology-aware project tooling (being retired): its pre-commit and standards value is consolidating into devkit slash commands and the esolia-standards MCP.",
+  "repo": "RickCogley/aichaku",
+  "audience": "public",
+  "stack": ["deno", "typescript"],
+  "owners": ["RickCogley"],
+  "status": "sunset",
+  "sensitivity": {
+    "overview": "org",
+    "topology": "dev",
+    "security": "dev"
+  },
+  "exposes": [
+    { "name": "aichaku CLI", "kind": "library" }
+  ],
+  "links": {
+    "retirement": "https://github.com/RickCogley/aichaku/issues/17"
+  }
+}


### PR DESCRIPTION
## Summary

Adds this repo's `.esolia/system.json` so it appears in the eSolia suite-context map served by the Standards MCP. Records the system with `status: sunset` to document its retirement. Harvested read-only by eSolia/devkit's aggregator (now includes shared-infrastructure repos via `SUITE_INFRA_REPOS`).

## Test plan

- [x] Validates against devkit's `.esolia/system.schema.json` (ajv + ajv-formats).
- [x] `deno fmt --check` clean.
- [x] Non-secret metadata only.

Closes #19

InfoSec: no security impact — additive non-secret descriptor; no code or runtime change.
